### PR TITLE
CUPS server info to MQTT, error handling, MQTT retain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,47 +43,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -108,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backon"
@@ -147,9 +148,9 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -189,9 +190,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 
 [[package]]
 name = "cfg-if"
@@ -226,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "colored"
@@ -938,6 +939,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,9 +1084,9 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-traits"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
@@ -1201,9 +1208,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fb059dee1a7b802f036316d790138c613a4e8b180c822e3925a662e9f0c95"
+checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1212,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73541b156d32197eecda1a4014d7f868fd2bcb3c550d5386087cfba442bf69c"
+checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1222,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35eeed0a3fab112f75165fdc026b3913f4183133f19b49be773ac9ea966e8bd"
+checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1235,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.9"
+version = "2.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adbf29bb9776f28caece835398781ab24435585fe0d4dc1374a61db5accedca"
+checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
 dependencies = [
  "once_cell",
  "pest",
@@ -1428,7 +1435,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -1587,7 +1594,7 @@ version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
@@ -1768,18 +1775,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "ddc6f9cc94d67c0e21aaf7eda3a010fd3af78ebf6e096aa6e2e13c79749cce4f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.200"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "856f046b9400cee3c8c94ed572ecdb752444c24528c035cd35882aad6f492bcb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2216,7 +2223,7 @@ version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "log",
  "native-tls",
  "once_cell",

--- a/src/cups_client/client.rs
+++ b/src/cups_client/client.rs
@@ -1,5 +1,3 @@
-use std::{collections::HashMap, io::Cursor};
-use chrono::DateTime;
 use ipp::prelude::*;
 use url::Url;
 use anyhow::{Context, Result};
@@ -8,17 +6,48 @@ use crate::config::models::Cups;
 
 use super::models::{*};
 
-pub fn build_cups_url(cups_settings: &Cups, queue_id: Option<String>) -> String {
-    let mut cups_url = Url::parse(&cups_settings.uri).unwrap();
-    if !cups_settings.username.is_empty() && !cups_settings.password.is_empty() {
-        cups_url.set_username(&cups_settings.username).unwrap();
-        cups_url.set_password(Some(&cups_settings.password)).unwrap();
+// //////////// //
+// Print queues //
+// //////////// //
+
+pub fn get_print_queues(uri: String, ignore_tls_errors: bool) -> Result<Vec<IppPrintQueueState>> {
+    let resp = send_ipp_request(uri.clone(), ignore_tls_errors, Operation::CupsGetPrinters);
+    let mut vec: Vec<IppPrintQueueState> = Vec::new();
+
+    for printer in resp?.attributes().groups_of(DelimiterTag::PrinterAttributes) {
+        let group = printer.attributes().clone();
+        let state = group["printer-state"]
+            .value()
+            .as_enum()
+            .and_then(|v| PrinterState::from_i32(*v)).context("Failed to parse printer state")?;
+        let job_count = group["queued-job-count"].value().as_integer().context("Failed to parse job count")?.clone();
+        let state_message = group["printer-state-message"].value().to_string().clone();
+        let queue_name = group["printer-name"].value().to_string().clone();
+        let description = group["printer-info"].value().to_string().clone();
+        let printer_make = group["printer-make-and-model"].value().to_string().clone();
+        let state_reason = group["printer-state-reasons"].value().to_string().clone();
+        let cups_version = group["cups-version"].value().to_string().clone();
+        vec.push(IppPrintQueueState { queue_name, description, printer_make, state, job_count, state_message, state_reason, cups_version });
     }
 
-    match queue_id {
-        Some(queue_id) => cups_url.join("printers/").unwrap().join(&queue_id).unwrap(),
+    Ok(vec)
+}
+
+// /////// //
+// Helpers //
+// /////// //
+
+pub fn build_cups_url(cups_settings: &Cups, queue_id: Option<String>) -> Result<String> {
+    let mut cups_url = Url::parse(&cups_settings.uri)?;
+    if !cups_settings.username.is_empty() && !cups_settings.password.is_empty() {
+        cups_url.set_username(&cups_settings.username).unwrap(); // FIXME: use .? instead of .unwrap()
+        cups_url.set_password(Some(&cups_settings.password)).unwrap(); // FIXME: use .? instead of .unwrap()
+    }
+
+    Ok(match queue_id {
+        Some(queue_id) => cups_url.join("printers/")?.join(&queue_id)?,
         None => cups_url,
-    }.to_string()
+    }.to_string())
 }
 
 /// Send an IPP request to do `op` to the given `uri` and get the response.
@@ -45,158 +74,4 @@ fn send_ipp_request(uri: String, ignore_tls_errors: bool, op: Operation) -> Resu
     let client = IppClient::builder(uri_p).ignore_tls_errors(ignore_tls_errors).build();
     let resp = client.send(req);
     Ok(resp?)
-}
-
-/// Send an IPP request to do `op` to job `job_id` to the given `uri` and get the response.
-///
-/// # Arguments
-///
-/// * `uri`: Printer or server URI
-/// * `op`: Operation
-/// * `job_id`: Job id
-///
-/// returns: Result<IppRequestResponse, IppError>
-///
-/// # Examples
-///
-/// ```
-/// send_ipp_job_request(uri, Operation::RestartJob, job_id).header().status_code().is_success()
-/// ```
-fn send_ipp_job_request(uri: String, ignore_tls_errors: bool, op: Operation, job_id: i32) -> Result<IppRequestResponse> {
-    let uri_p: Uri = uri.parse()?;
-    let mut req = IppRequestResponse::new(
-        IppVersion::v1_1(),
-        op,
-        Some(uri_p.clone())
-    );
-    req.attributes_mut().add(
-        DelimiterTag::OperationAttributes,
-        IppAttribute::new(IppAttribute::JOB_ID, IppValue::Integer(job_id)),
-    );
-
-    let client = IppClient::builder(uri_p).ignore_tls_errors(ignore_tls_errors).build();
-    let resp = client.send(req);
-    Ok(resp?)
-}
-
-pub fn resume_printer(uri: String, ignore_tls_errors: bool) -> Result<bool> {
-    Ok(send_ipp_request(uri, ignore_tls_errors, Operation::ResumePrinter)?.header().status_code().is_success())
-}
-
-pub fn purge_jobs(uri: String, ignore_tls_errors: bool) -> Result<bool> {
-    Ok(send_ipp_request(uri, ignore_tls_errors, Operation::PurgeJobs)?.header().status_code().is_success())
-}
-
-pub fn print_job(uri: String, ignore_tls_errors: bool, job_name: String, pdf_data: Vec<u8>) -> bool {
-    let uri_p: Uri = uri.parse().unwrap();
-    let pdf_data_cursor = Cursor::new(pdf_data);
-    let pdf_data_payload = IppPayload::new(pdf_data_cursor);
-    let print_job = IppOperationBuilder::print_job(uri_p.clone(), pdf_data_payload).job_title(job_name);
-
-    let client = IppClient::builder(uri_p).ignore_tls_errors(ignore_tls_errors).build();
-    let resp = client.send(print_job.build());
-    resp.unwrap().header().status_code().is_success()
-}
-
-pub fn restart_job(uri: String, ignore_tls_errors: bool, job_id: i32) -> Result<bool> {
-    Ok(send_ipp_job_request(uri, ignore_tls_errors, Operation::RestartJob, job_id)?.header().status_code().is_success())
-}
-
-pub fn release_job(uri: String, ignore_tls_errors: bool, job_id: i32) -> Result<bool> {
-    Ok(send_ipp_job_request(uri, ignore_tls_errors, Operation::ReleaseJob, job_id)?.header().status_code().is_success())
-}
-
-pub fn cancel_job(uri: String, ignore_tls_errors: bool, job_id: i32) -> Result<bool> {
-    Ok(send_ipp_job_request(uri, ignore_tls_errors, Operation::CancelJob, job_id)?.header().status_code().is_success())
-}
-
-pub fn get_printers(uri: String, ignore_tls_errors: bool) -> Result<Vec<IppPrinterState>> {
-    let resp = send_ipp_request(uri.clone(), ignore_tls_errors, Operation::CupsGetPrinters);
-    let mut vec: Vec<IppPrinterState> = Vec::new();
-
-    for printer in resp?.attributes().groups_of(DelimiterTag::PrinterAttributes) {
-        let group = printer.attributes().clone();
-        let state = group["printer-state"]
-            .value()
-            .as_enum()
-            .and_then(|v| PrinterState::from_i32(*v))
-            .unwrap();
-        let job_count = group["queued-job-count"].value().as_integer().unwrap().clone();
-        let state_message = group["printer-state-message"].value().to_string().clone();
-        let queue_name = group["printer-name"].value().to_string().clone();
-        let description = group["printer-info"].value().to_string().clone();
-        let printer_make = group["printer-make-and-model"].value().to_string().clone();
-        let state_reason = group["printer-state-reasons"].value().to_string().clone();
-        vec.push(IppPrinterState { queue_name, description, printer_make, state, job_count, state_message, state_reason });
-    }
-
-    Ok(vec)
-}
-
-pub fn get_printer_state(uri: String, ignore_tls_errors: bool) -> Result<IppPrinterState> {
-    let resp = send_ipp_request(uri.clone(), ignore_tls_errors, Operation::GetPrinterAttributes)?;
-
-    let group = resp.attributes().groups_of(DelimiterTag::PrinterAttributes).next().context("Invalid group returned")?;
-    let attributes = group.attributes().clone();
-
-    let state = group.attributes()["printer-state"]
-        .value()
-        .as_enum()
-        .and_then(|v| PrinterState::from_i32(*v))
-        .unwrap();
-    let job_count = attributes["queued-job-count"].value().as_integer().context("Could not parse queued-job-count to i32")?.clone();
-    let state_message = attributes["printer-state-message"].value().to_string().clone();
-    let queue_name = attributes["printer-name"].value().to_string().clone();
-    let description = attributes["printer-info"].value().to_string().clone();
-    let printer_make = attributes["printer-make-and-model"].value().to_string().clone();
-    let state_reason = attributes["printer-state-reasons"].value().to_string().clone();
-    //print_attributes(attributes);
-    Ok(IppPrinterState { queue_name, description, printer_make, state, job_count, state_message, state_reason })
-}
-
-pub fn get_jobs_states(uri: String, ignore_tls_errors: bool) -> Result<Vec<PrintJobState>> {
-    let resp = send_ipp_request(uri.clone(), ignore_tls_errors, Operation::GetJobs);
-    let mut vec: Vec<PrintJobState> = Vec::new();
-
-    for job in resp?.attributes().groups_of(DelimiterTag::JobAttributes) {
-        let job_id = job.attributes()["job-id"].value().as_integer().context("Could not convert job-id to i32")?.clone();
-        vec.push(get_job_state(uri.clone(), ignore_tls_errors, job_id)?);
-    }
-
-    // print_attributes(attributes);
-    Ok(vec)
-}
-
-fn get_job_state(uri: String, ignore_tls_errors: bool, job_id: i32) -> Result<PrintJobState> {
-    let resp = send_ipp_job_request(uri.clone(), ignore_tls_errors, Operation::GetJobAttributes, job_id)?;
-
-    let group = resp.attributes().groups_of(DelimiterTag::JobAttributes).next().context("Invalid group returned")?;
-    let attributes = group.attributes().clone();
-
-    // print_attributes(attributes.clone());
-
-    let state = group.attributes()["job-state"]
-        .value()
-        .as_enum()
-        .and_then(|v| JobState::from_i32(*v))
-        .context("Could not convert i32 value to JobState")?;
-
-    let creation_time = DateTime::from_timestamp_millis((attributes["time-at-creation"].value().as_integer().context("Could not convert time-at-creation to i32")?.clone() as i64) * 1000).unwrap();
-
-    // Not every job seems to have a name
-    let job_name = if attributes.get_key_value("job-name").is_some() { attributes["job-name"].value().to_string().clone() } else { "".to_string() };
-
-    Ok(PrintJobState {
-        name: job_name,
-        id: attributes["job-id"].value().as_integer().unwrap().clone(),
-        state: state,
-        reason: attributes["job-state-reasons"].value().to_string().clone(),
-        created: creation_time,
-    })
-}
-
-fn print_attributes(attributes: HashMap<String, IppAttribute>) {
-    for attribute in attributes {
-        println!("Attribute {}: {:?}", attribute.0, attribute.1.value());
-    }
 }

--- a/src/cups_client/models.rs
+++ b/src/cups_client/models.rs
@@ -1,8 +1,7 @@
-use chrono::{DateTime, Utc};
-use ipp::model::{JobState, PrinterState};
+use ipp::model::PrinterState;
 
 #[derive(Debug)]
-pub struct IppPrinterState {
+pub struct IppPrintQueueState {
     pub queue_name: String,
     pub description: String,
     pub printer_make: String,
@@ -10,13 +9,5 @@ pub struct IppPrinterState {
     pub job_count: i32,
     pub state_message: String,
     pub state_reason: String,
-}
-
-#[derive(Debug)]
-pub struct PrintJobState {
-    pub name: String,
-    pub id: i32,
-    pub state: JobState,
-    pub reason: String,
-    pub created: DateTime<Utc>,
+    pub cups_version: String,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,14 @@
 use std::sync::OnceLock;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use config::models::Settings;
-use backon::BlockingRetryable;
-use backon::ExponentialBuilder;
-use convert_case::Converter;
-use convert_case::Pattern;
-use cups_client::models::IppPrinterState;
+use backon::{BlockingRetryable, ExponentialBuilder};
+use convert_case::{Converter, Pattern};
+use cups_client::models::IppPrintQueueState;
 use dashmap::DashMap;
-use log::debug;
-use log::error;
-use log::info;
-use mqtt_client::client::MqttClient;
-use mqtt_client::models::HomeAssistantDevice;
-use mqtt_client::models::HomeAssistantDiscoverySensorPayload;
-use mqtt_client::models::MqttCupsPrintQueueStatus;
+use log::{debug, error, info};
+use mqtt_client::{client::MqttClient, models::*};
+use url::Url;
 
 mod cups_client;
 mod config;
@@ -63,25 +57,109 @@ fn failure_wait() {
 }
 
 fn publish_cups_queue_statuses_and_log_result() -> Result<()> {
-    match publish_cups_queue_statuses() {
-        Ok(count) => {
-            debug!("Published {} queue statuses", count);
-            Ok(())
+    let settings = get_settings();
+    let url = cups_client::client::build_cups_url(&settings.cups, None);
+    let print_queues_result = cups_client::client::get_print_queues(url?.clone(), settings.cups.ignore_tls_errors);
+
+    match &print_queues_result {
+        Ok(print_queues) => {
+            debug!("Got print queues: {}", print_queues.len());
         },
         Err(e) => {
-            error!("Failed to publish queue statuses: {}", e);
+            error!("Failed to get print queues (CUPS offline?): {}", e);
+        }
+    }
+
+    match publish_cups_server_status(&print_queues_result) {
+        Ok(_) => {
+            debug!("Published server status");
+        },
+        Err(e) => {
+            error!("Failed to publish server status (MQTT offline?): {}", e);
+            return Err(e);
+        }
+    }
+
+    match print_queues_result {
+        Ok(print_queues) => {
+            // CUPS online, publish print queues.
+            match publish_cups_queue_statuses(print_queues) {
+                Ok(()) => {
+                    debug!("Published queue statuses");
+                    Ok(())
+                },
+                Err(e) => {
+                    error!("Failed to publish queue statuses (MQTT offline?): {}", e);
+                    Err(e)
+                }
+            }
+        },
+        Err(e) => {
+            // CUPS offline, publish server status only.
             Err(e)
         }
     }
 }
 
-fn publish_cups_queue_statuses() -> Result<usize> {
-    let settings = get_settings();
-    let url = cups_client::client::build_cups_url(&settings.cups, None);
-    let result = cups_client::client::get_printers(url, settings.cups.ignore_tls_errors)?;
+// //////////////////// //
+// Print server publish //
+// //////////////////// //
 
-    let queue_count = result.len();
-    for queue in result {
+fn publish_cups_server_status(print_queues_result: &Result<Vec<IppPrintQueueState>>) -> Result<()> {
+    let settings = get_settings();
+
+    let cups_version = match print_queues_result {
+            Ok(print_queues) => print_queues.first().map(|q| q.cups_version.clone()),
+            Err(_) => None,
+        };
+
+    let topic = format!("{}/{}", settings.mqtt.root_topic, "cups_server");
+    let payload = serde_json::to_string(&MqttCupsServerStatus {
+        is_reachable: print_queues_result.is_ok(),
+        cups_version: cups_version.clone(),
+        cups2mqtt_version: env!("CARGO_PKG_VERSION").to_owned(),
+    })?;
+    publish(&topic, payload)?;
+
+    if settings.mqtt.ha.enable_discovery {
+        publish_ha_bridge_discovery_topic(&cups_version, "cups_version", "CUPS version")?;
+        publish_ha_bridge_discovery_topic(&cups_version, "cups2mqtt_version", "CUPS2MQTT version")?;
+    }
+
+    Ok(())
+}
+
+fn publish_ha_bridge_discovery_topic(cups_version: &Option<String>, integration_name: &str, sensor_name: &str) -> Result<()> {
+    let settings = get_settings();
+
+    let url = Url::parse(&settings.cups.uri)?;
+    let display_url = format!("{}:{}", url.host_str().context("Failed to get host")?, url.port().unwrap_or(631));
+
+    let topic = format!("{}/sensor/{}_cups_server/{}/config", settings.mqtt.ha.discovery_topic_prefix, settings.mqtt.ha.component_id, integration_name);
+    let payload = serde_json::to_string(&HomeAssistantDiscoverySensorPayload {
+        name: sensor_name.to_owned(),
+        state_topic: format!("{}/cups_server", settings.mqtt.root_topic),
+        unique_id: format!("cups_server_{}_{}", integration_name, settings.mqtt.ha.component_id),
+        value_template: format!("{{{{ value_json.{} }}}}", integration_name),
+        device: HomeAssistantDevice {
+            identifiers: vec![format!("{}_cups_server", settings.mqtt.ha.component_id)],
+            name: format!("CUPS @ {}", display_url),
+            model: "CUPS print server".to_owned(),
+            sw_version: cups_version.clone(),
+            via_device: None,
+        },
+    })?;
+    Ok(publish(&topic, payload)?)
+}
+
+// /////////////////// //
+// Print queue publish //
+// /////////////////// //
+
+fn publish_cups_queue_statuses(print_queues: Vec<IppPrintQueueState>) -> Result<()> {
+    let settings = get_settings();
+
+    for queue in print_queues {
         let queue_name = queue.queue_name.clone();
 
         let topic = format!("{}/{}", settings.mqtt.root_topic, queue_name);
@@ -89,40 +167,19 @@ fn publish_cups_queue_statuses() -> Result<usize> {
         publish(&topic, payload)?;
 
         if settings.mqtt.ha.enable_discovery {
-            publish_ha_sensor_discovery_topic(&queue, "name".to_owned())?;
-            publish_ha_sensor_discovery_topic(&queue, "description".to_owned())?;
-            publish_ha_sensor_discovery_topic(&queue, "state".to_owned())?;
-            publish_ha_sensor_discovery_topic(&queue, "job_count".to_owned())?;
-            publish_ha_sensor_discovery_topic(&queue, "state_message".to_owned())?;
-            publish_ha_sensor_discovery_topic(&queue, "state_reason".to_owned())?;
+            publish_ha_sensor_discovery_topic(&queue, "name")?;
+            publish_ha_sensor_discovery_topic(&queue, "description")?;
+            publish_ha_sensor_discovery_topic(&queue, "state")?;
+            publish_ha_sensor_discovery_topic(&queue, "job_count")?;
+            publish_ha_sensor_discovery_topic(&queue, "state_message")?;
+            publish_ha_sensor_discovery_topic(&queue, "state_reason")?;
         }
     }
 
-    Ok(queue_count)
+    Ok(())
 }
 
-fn publish_ha_bridge_discovery_topic() -> Result<()> {
-    let settings = get_settings();
-    let case_converter = Converter::new().set_pattern(Pattern::Sentence).set_delim(" ");
-
-    let topic = format!("{}/sensor/{}/cups2mqtt_version/config", settings.mqtt.ha.discovery_topic_prefix, settings.mqtt.ha.component_id);
-    let payload = serde_json::to_string(&HomeAssistantDiscoverySensorPayload {
-        name: "CUPS2MQTT version".to_owned(),
-        state_topic: format!("{}/{}", settings.mqtt.root_topic, "cups_server"),
-        unique_id: format!("cups2mqtt_version_{}", settings.mqtt.ha.component_id),
-        value_template: "{{ value_json.version }}".to_owned(),
-        device: HomeAssistantDevice {
-            identifiers: vec![format!("CUPS_{}", settings.mqtt.ha.component_id)],
-            name: format!("CUPS @ {}", settings.cups.uri),
-            model: "CUPS Print Server".to_owned(),
-            sw_version: env!("CARGO_PKG_VERSION").to_owned(),
-            via_device: None,
-        },
-    })?;
-    Ok(publish(&topic, payload)?)
-}
-
-fn publish_ha_sensor_discovery_topic(queue: &IppPrinterState, integration_name: String) -> Result<()> {
+fn publish_ha_sensor_discovery_topic(queue: &IppPrintQueueState, integration_name: &str) -> Result<()> {
     let settings = get_settings();
     let case_converter = Converter::new().set_pattern(Pattern::Sentence).set_delim(" ");
 
@@ -136,16 +193,20 @@ fn publish_ha_sensor_discovery_topic(queue: &IppPrinterState, integration_name: 
             identifiers: vec![format!("{}_{}", settings.mqtt.ha.component_id, queue.queue_name.to_owned())],
             name: queue.description.to_owned(),
             model: queue.printer_make.to_owned(),
-            sw_version: env!("CARGO_PKG_VERSION").to_owned(),
-            via_device: Some(settings.mqtt.ha.component_id.clone()),
+            sw_version: None,
+            via_device: Some(format!("{}_cups_server", settings.mqtt.ha.component_id)),
         },
     })?;
     Ok(publish(&topic, payload)?)
 }
 
+// /////// //
+// Helpers //
+// /////// //
+
 fn publish(topic: &str, payload: String) -> Result<()> {
     let last_published = get_last_published_mqtt_messages().get(topic);
-    Ok(if last_published.is_none() || !last_published.unwrap().eq(&payload) {
+    Ok(if last_published.is_none() || !last_published.context("Failed to get last published message")?.eq(&payload) {
         get_last_published_mqtt_messages().insert(topic.to_owned(), payload.clone());
         get_mqtt_client().publish(topic, payload.as_bytes())?;
     })

--- a/src/mqtt_client/client.rs
+++ b/src/mqtt_client/client.rs
@@ -39,6 +39,6 @@ impl MqttClient {
     }
 
     pub fn publish(&self, topic: &str, payload: &[u8]) -> Result<()> {
-        Ok(self.client.publish(topic, QoS::AtLeastOnce, false, payload)?)
+        Ok(self.client.publish(topic, QoS::AtLeastOnce, true, payload)?)
     }
 }

--- a/src/mqtt_client/models.rs
+++ b/src/mqtt_client/models.rs
@@ -72,4 +72,5 @@ pub struct HomeAssistantDevice {
     pub model: String,
     pub name: String,
     pub sw_version: String,
+    pub via_device: Option<String>,
 }

--- a/src/mqtt_client/models.rs
+++ b/src/mqtt_client/models.rs
@@ -1,11 +1,18 @@
 use ipp::model::PrinterState;
 use serde::{Deserialize, Serialize};
 
-use crate::cups_client::models::IppPrinterState;
+use crate::cups_client::models::IppPrintQueueState;
 
 // ////// //
 // Status //
 // ////// //
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MqttCupsServerStatus {
+    pub is_reachable: bool,
+    pub cups_version: Option<String>,
+    pub cups2mqtt_version: String,
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MqttCupsPrintQueueStatus {
@@ -25,8 +32,8 @@ pub enum MqttCupsPrinterState {
     Stopped = 5,
 }
 
-impl From<&IppPrinterState> for MqttCupsPrintQueueStatus {
-    fn from(status: &IppPrinterState) -> Self {
+impl From<&IppPrintQueueState> for MqttCupsPrintQueueStatus {
+    fn from(status: &IppPrintQueueState) -> Self {
         MqttCupsPrintQueueStatus {
             name: status.queue_name.clone(),
             description: status.description.clone(),
@@ -71,6 +78,8 @@ pub struct HomeAssistantDevice {
     pub identifiers: Vec<String>,
     pub model: String,
     pub name: String,
-    pub sw_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sw_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub via_device: Option<String>,
 }


### PR DESCRIPTION
This PR:
- Improves error handling and logging
- Adds presenting the CUPS server as device to Home Assistant (with correct topology for print queues vs. print server)
- Enables MQTT retain